### PR TITLE
Add Localities endpoints and tests

### DIFF
--- a/cmd/server/handler/locality.go
+++ b/cmd/server/handler/locality.go
@@ -21,6 +21,18 @@ func NewLocality(svc localities.Service) *Locality {
 	}
 }
 
+// Create godoc
+//
+//	@Summary	Create new locality
+//	@Tags		Localities
+//	@Accept		json
+//	@Produce	json
+//	@Param		locality	body		localities.CreateDTO	true	"Locality to be added"
+//	@Success	201			{object}	web.response			"Returns created locality"
+//	@Failure	409			{object}	web.errorResponse		"Locality is not unique"
+//	@Failure	422			{object}	web.errorResponse		"Missing fields or invalid field types"
+//	@Failure	500			{object}	web.errorResponse		"Could not save locality"
+//	@Router		/api/v1/localities [post]
 func (h *Locality) Create() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		dto := middleware.GetBody[localities.CreateDTO](c)
@@ -36,6 +48,16 @@ func (h *Locality) Create() gin.HandlerFunc {
 	}
 }
 
+// ReportAll godoc
+//
+//	@Summary	Return seller count for each locality
+//	@Tags		Localities
+//	@Accept		json
+//	@Produce	json
+//	@Success	200	{object}	web.response		"Returns seller count for localities"
+//	@Success	204	{object}	web.response		"No content was found"
+//	@Failure	500	{object}	web.errorResponse	"Could not save locality"
+//	@Router		/api/v1/localities/report-sellers [get]
 func (h *Locality) SellerReport() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var id optional.Opt[int]
@@ -58,6 +80,19 @@ func (h *Locality) SellerReport() gin.HandlerFunc {
 		web.Success(c, http.StatusOK, report)
 	}
 }
+
+// ReportByID godoc
+//
+//	@Summary	Return seller count for given locality
+//	@Tags		Localities
+//	@Accept		json
+//	@Produce	json
+//	@Param		id	path		int					true	"Locality ID"
+//	@Success	200	{object}	web.response		"Returns seller count for locality"
+//	@Failure	404	{object}	web.response		"ID was not found"
+//	@Failure	500	{object}	web.errorResponse	"Could not save locality"
+//	@Router		/api/v1/localities/report-sellers/{id} [get]x
+func _() {} // Implementation is in the SellerReport function
 
 func mapLocalityErrToStatus(err error) int {
 	var invalidLocality *localities.ErrInvalidLocality

--- a/cmd/server/handler/locality.go
+++ b/cmd/server/handler/locality.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/localities"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/optional"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/web"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/web/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+type Locality struct {
+	locService localities.Service
+}
+
+func NewLocality(svc localities.Service) *Locality {
+	return &Locality{
+		locService: svc,
+	}
+}
+
+func (h *Locality) Create() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		dto := middleware.GetBody[localities.CreateDTO](c)
+
+		loc, err := h.locService.Create(c.Request.Context(), dto)
+		if err != nil {
+			status := mapLocalityErrToStatus(err)
+			web.Error(c, status, err.Error())
+			return
+		}
+
+		web.Success(c, http.StatusCreated, loc)
+	}
+}
+
+func (h *Locality) SellerReport() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var id optional.Opt[int]
+		if _, hasId := c.Params.Get("id"); hasId {
+			id = *optional.FromVal(c.GetInt("id"))
+		}
+
+		report, err := h.locService.CountSellers(c, id)
+
+		if err != nil {
+			status := mapLocalityErrToStatus(err)
+			web.Error(c, status, err.Error())
+			return
+		}
+
+		if len(report) == 0 {
+			web.Success(c, http.StatusNoContent, report)
+			return
+		}
+		web.Success(c, http.StatusOK, report)
+	}
+}
+
+func mapLocalityErrToStatus(err error) int {
+	var invalidLocality *localities.ErrInvalidLocality
+	var notFound *localities.ErrNotFound
+
+	if errors.As(err, &invalidLocality) {
+		return http.StatusConflict
+	}
+	if errors.As(err, &notFound) {
+		return http.StatusNotFound
+	}
+	return http.StatusInternalServerError
+}

--- a/cmd/server/handler/locality.go
+++ b/cmd/server/handler/locality.go
@@ -91,7 +91,7 @@ func (h *Locality) SellerReport() gin.HandlerFunc {
 //	@Success	200	{object}	web.response		"Returns seller count for locality"
 //	@Failure	404	{object}	web.response		"ID was not found"
 //	@Failure	500	{object}	web.errorResponse	"Could not save locality"
-//	@Router		/api/v1/localities/report-sellers/{id} [get]x
+//	@Router		/api/v1/localities/report-sellers/{id} [get]
 func _() {} // Implementation is in the SellerReport function
 
 func mapLocalityErrToStatus(err error) int {

--- a/cmd/server/handler/locality_test.go
+++ b/cmd/server/handler/locality_test.go
@@ -1,27 +1,192 @@
 package handler_test
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/cmd/server/handler"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/localities"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/optional"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/testutil"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/web/middleware"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const LOCALITY_URL = "/localities"
 
 func TestLocalityCreate(t *testing.T) {
 	t.Run("Returns 201 if locality is created successfully", func(t *testing.T) {
+		svc := LocalityServiceMock{}
+		h := handler.NewLocality(&svc)
+		server := getLocalityServer(h)
 
+		dto := localities.CreateDTO{
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "BR",
+		}
+		expected := domain.Locality{
+			ID:       1,
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "BR",
+		}
+		svc.On("Create", mock.Anything, mock.Anything).Return(expected, nil)
+
+		req, res := testutil.MakeRequest(http.MethodPost, LOCALITY_URL, dto)
+		server.ServeHTTP(res, req)
+
+		var response testutil.SuccessResponse[domain.Locality]
+		json.Unmarshal(res.Body.Bytes(), &response)
+
+		assert.Equal(t, http.StatusCreated, res.Code)
+		assert.Equal(t, expected, response.Data)
 	})
 	t.Run("Returns 409 if locality already exists", func(t *testing.T) {
+		svc := LocalityServiceMock{}
+		h := handler.NewLocality(&svc)
+		server := getLocalityServer(h)
 
+		dto := localities.CreateDTO{
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "BR",
+		}
+		svc.On("Create", mock.Anything, mock.Anything).Return(domain.Locality{}, &localities.ErrInvalidLocality{})
+
+		req, res := testutil.MakeRequest(http.MethodPost, LOCALITY_URL, dto)
+		server.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusConflict, res.Code)
 	})
 }
 
 func TestLocalityReport(t *testing.T) {
 	t.Run("Returns all localities if id is omitted", func(t *testing.T) {
+		svc := LocalityServiceMock{}
+		h := handler.NewLocality(&svc)
+		server := getLocalityServer(h)
 
+		expected := getSellerCounts()
+		svc.On("CountSellers", mock.Anything, mock.Anything).Return(expected, nil)
+
+		req, res := testutil.MakeRequest(http.MethodGet, LOCALITY_URL, nil)
+		server.ServeHTTP(res, req)
+
+		var response testutil.SuccessResponse[[]localities.SellersByLocality]
+		json.Unmarshal(res.Body.Bytes(), &response)
+
+		assert.Equal(t, http.StatusOK, res.Code)
+		assert.ElementsMatch(t, expected, response.Data)
 	})
 	t.Run("Returns single locality if id is given", func(t *testing.T) {
+		svc := LocalityServiceMock{}
+		h := handler.NewLocality(&svc)
+		server := getLocalityServer(h)
 
+		expected := getSellerCounts()[:1]
+		id := *optional.FromVal(expected[0].ID)
+		svc.On("CountSellers", mock.Anything, id).Return(expected, nil)
+
+		url := fmt.Sprintf("%s/%d", LOCALITY_URL, id.Val)
+		req, res := testutil.MakeRequest(http.MethodGet, url, nil)
+		server.ServeHTTP(res, req)
+
+		var response testutil.SuccessResponse[[]localities.SellersByLocality]
+		json.Unmarshal(res.Body.Bytes(), &response)
+
+		assert.Equal(t, http.StatusOK, res.Code)
+		assert.ElementsMatch(t, expected, response.Data)
 	})
 	t.Run("Returns 404 if id is not found", func(t *testing.T) {
+		svc := LocalityServiceMock{}
+		h := handler.NewLocality(&svc)
+		server := getLocalityServer(h)
 
+		id := *optional.FromVal(42)
+		svc.On("CountSellers", mock.Anything, id).Return([]localities.SellersByLocality{}, localities.NewErrNotFound(id.Val))
+
+		url := fmt.Sprintf("%s/%d", LOCALITY_URL, id.Val)
+		req, res := testutil.MakeRequest(http.MethodGet, url, nil)
+		server.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusNotFound, res.Code)
 	})
 	t.Run("Returns 201 if no id is given and there is no data", func(t *testing.T) {
+		t.Run("Returns 404 if id is not found", func(t *testing.T) {
+			svc := LocalityServiceMock{}
+			h := handler.NewLocality(&svc)
+			server := getLocalityServer(h)
 
+			id := optional.Opt[int]{}
+			svc.On("CountSellers", mock.Anything, id).Return([]localities.SellersByLocality{}, nil)
+
+			req, res := testutil.MakeRequest(http.MethodGet, LOCALITY_URL, nil)
+			server.ServeHTTP(res, req)
+
+			var response testutil.SuccessResponse[[]localities.SellersByLocality]
+			json.Unmarshal(res.Body.Bytes(), &response)
+
+			assert.Equal(t, http.StatusNoContent, res.Code)
+			assert.Len(t, response.Data, 0)
+		})
 	})
+	t.Run("Returns 590 if repository fails", func(t *testing.T) {
+		svc := LocalityServiceMock{}
+		h := handler.NewLocality(&svc)
+		server := getLocalityServer(h)
+
+		svc.On("CountSellers", mock.Anything, mock.Anything).Return([]localities.SellersByLocality{}, localities.NewErrGeneric(""))
+
+		req, res := testutil.MakeRequest(http.MethodGet, LOCALITY_URL, nil)
+		server.ServeHTTP(res, req)
+
+		assert.Equal(t, http.StatusInternalServerError, res.Code)
+	})
+}
+
+func getSellerCounts() []localities.SellersByLocality {
+	return []localities.SellersByLocality{
+		{
+			ID:    1,
+			Name:  "Melicidade",
+			Count: 2,
+		},
+		{
+			ID:    2,
+			Name:  "Tesla",
+			Count: 1,
+		},
+	}
+}
+
+func getLocalityServer(h *handler.Locality) *gin.Engine {
+	s := testutil.CreateServer()
+	rg := s.Group(LOCALITY_URL)
+	{
+		rg.POST("", middleware.Body[localities.CreateDTO](), h.Create())
+		rg.GET("", h.SellerReport())
+		rg.GET("/:id", middleware.IntPathParam(), h.SellerReport())
+	}
+	return s
+}
+
+type LocalityServiceMock struct {
+	mock.Mock
+}
+
+func (s *LocalityServiceMock) Create(c context.Context, loc localities.CreateDTO) (domain.Locality, error) {
+	args := s.Called(c, loc)
+	return args.Get(0).(domain.Locality), args.Error(1)
+}
+
+func (s *LocalityServiceMock) CountSellers(c context.Context, id optional.Opt[int]) ([]localities.SellersByLocality, error) {
+	args := s.Called(c, id)
+	return args.Get(0).([]localities.SellersByLocality), args.Error(1)
 }

--- a/cmd/server/handler/locality_test.go
+++ b/cmd/server/handler/locality_test.go
@@ -1,0 +1,27 @@
+package handler_test
+
+import "testing"
+
+func TestLocalityCreate(t *testing.T) {
+	t.Run("Returns 201 if locality is created successfully", func(t *testing.T) {
+
+	})
+	t.Run("Returns 409 if locality already exists", func(t *testing.T) {
+
+	})
+}
+
+func TestLocalityReport(t *testing.T) {
+	t.Run("Returns all localities if id is omitted", func(t *testing.T) {
+
+	})
+	t.Run("Returns single locality if id is given", func(t *testing.T) {
+
+	})
+	t.Run("Returns 404 if id is not found", func(t *testing.T) {
+
+	})
+	t.Run("Returns 201 if no id is given and there is no data", func(t *testing.T) {
+
+	})
+}

--- a/cmd/server/handler/product.go
+++ b/cmd/server/handler/product.go
@@ -67,7 +67,7 @@ func (p *Product) GetAll() gin.HandlerFunc {
 		ps, err := p.productService.GetAll(c.Request.Context())
 
 		if err != nil {
-			errStatus := mapErrorToStatus(err)
+			errStatus := mapProductErrToStatus(err)
 			web.Error(c, errStatus, err.Error())
 			return
 		}
@@ -98,7 +98,7 @@ func (p *Product) Get() gin.HandlerFunc {
 		p, err := p.productService.Get(c.Request.Context(), id)
 
 		if err != nil {
-			errStatus := mapErrorToStatus(err)
+			errStatus := mapProductErrToStatus(err)
 			web.Error(c, errStatus, err.Error())
 			return
 		}
@@ -125,7 +125,7 @@ func (p *Product) Create() gin.HandlerFunc {
 		p, err := p.productService.Create(c.Request.Context(), *dto)
 
 		if err != nil {
-			errStatus := mapErrorToStatus(err)
+			errStatus := mapProductErrToStatus(err)
 			web.Error(c, errStatus, err.Error())
 			return
 		}
@@ -158,7 +158,7 @@ func (p *Product) Update() gin.HandlerFunc {
 		p, err := p.productService.Update(c.Request.Context(), id, *dto)
 
 		if err != nil {
-			errStatus := mapErrorToStatus(err)
+			errStatus := mapProductErrToStatus(err)
 			web.Error(c, errStatus, err.Error())
 			return
 		}
@@ -186,7 +186,7 @@ func (p *Product) Delete() gin.HandlerFunc {
 		err := p.productService.Delete(c.Request.Context(), id)
 
 		if err != nil {
-			errStatus := mapErrorToStatus(err)
+			errStatus := mapProductErrToStatus(err)
 			web.Error(c, errStatus, err.Error())
 			return
 		}
@@ -194,7 +194,7 @@ func (p *Product) Delete() gin.HandlerFunc {
 	}
 }
 
-func mapErrorToStatus(err error) int {
+func mapProductErrToStatus(err error) int {
 	var invalidProductCode *product.ErrInvalidProductCode
 	var notFound *product.ErrNotFound
 

--- a/cmd/server/handler/warehouse.go
+++ b/cmd/server/handler/warehouse.go
@@ -90,7 +90,7 @@ func (w *Warehouse) GetAll() gin.HandlerFunc {
 //	@Param			warehouse	body		domain.Warehouse	true	"Warehouse object"
 //	@Success		201			{object}	domain.Warehouse
 //	@Failure		422			{string}	string	"warehousecode need to be passed, it can't be empty"
-//	@Failure		500			{string}	string	 "something went wrong with the request"
+//	@Failure		500			{string}	string	"something went wrong with the request"
 //	@Failure		409			{string}	string	"warehouse can be alreary exist"
 //	@Router			/api/v1/warehouses [post]
 func (w *Warehouse) Create() gin.HandlerFunc {

--- a/cmd/server/routes/routes.go
+++ b/cmd/server/routes/routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/buyer"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/employee"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/localities"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/product"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/section"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/seller"
@@ -43,6 +44,7 @@ func (r *router) MapRoutes() {
 	r.buildWarehouseRoutes()
 	r.buildEmployeeRoutes()
 	r.buildBuyerRoutes()
+	r.buildLocalityRoutes()
 }
 
 func (r *router) buildDocumentationRoutes() {
@@ -139,5 +141,18 @@ func (r *router) buildBuyerRoutes() {
 		buyerRG.GET("/:id", middleware.IntPathParam(), h.Get())
 		buyerRG.DELETE("/:id", middleware.IntPathParam(), h.Delete())
 		buyerRG.PATCH("/:id", middleware.IntPathParam(), middleware.Body[domain.Buyer](), h.Update())
+	}
+}
+
+func (r *router) buildLocalityRoutes() {
+	repo := localities.NewRepository(r.db)
+	service := localities.NewService(repo)
+	h := handler.NewLocality(service)
+
+	buyerRG := r.rg.Group("/localities")
+	{
+		buyerRG.POST("", middleware.Body[localities.CreateDTO](), h.Create())
+		buyerRG.GET("/report-sellers", h.SellerReport())
+		buyerRG.GET("/report-sellers/:id", middleware.IntPathParam(), h.SellerReport())
 	}
 }

--- a/db.sql
+++ b/db.sql
@@ -24,6 +24,7 @@ USE `melisprint` ;
 CREATE TABLE IF NOT EXISTS `melisprint`.`countries` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `country_name` VARCHAR(255) NOT NULL,
+  CONSTRAINT `country_name_UNIQUE` UNIQUE (`country_name`),
   PRIMARY KEY (`id`))
 ENGINE = InnoDB;
 
@@ -37,6 +38,7 @@ CREATE TABLE IF NOT EXISTS `melisprint`.`provinces` (
   `country_id` INT NOT NULL,
   PRIMARY KEY (`id`),
   INDEX `country_id_idx` (`country_id` ASC) VISIBLE,
+  CONSTRAINT `province_UNIQUE` UNIQUE (`province_name`, `country_id`),
   CONSTRAINT `fk_country_provinces`
     FOREIGN KEY (`country_id`)
     REFERENCES `melisprint`.`countries` (`id`)
@@ -54,6 +56,7 @@ CREATE TABLE IF NOT EXISTS `melisprint`.`localities` (
   `province_id` INT NOT NULL,
   PRIMARY KEY (`id`),
   INDEX `province_id_idx` (`province_id` ASC) VISIBLE,
+  CONSTRAINT `locality_UNIQUE` UNIQUE (`locality_name`, `province_id`),
   CONSTRAINT `fk_province_localities`
     FOREIGN KEY (`province_id`)
     REFERENCES `melisprint`.`provinces` (`id`)

--- a/internal/domain/locality.go
+++ b/internal/domain/locality.go
@@ -1,0 +1,8 @@
+package domain
+
+type Locality struct {
+	ID       int    `json:"id"`
+	Name     string `json:"locality_name"`
+	Province string `json:"province_name"`
+	Country  string `json:"country_name"`
+}

--- a/internal/localities/errors.go
+++ b/internal/localities/errors.go
@@ -1,0 +1,43 @@
+package localities
+
+import (
+	"fmt"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+)
+
+type ErrInvalidLocality struct {
+	Locality domain.Locality
+}
+
+type ErrNotFound struct {
+	ID int
+}
+
+type ErrGeneric struct {
+	message string
+}
+
+func NewErrGeneric(message string) *ErrGeneric {
+	return &ErrGeneric{message}
+}
+
+func (e ErrGeneric) Error() string {
+	return e.message
+}
+
+func NewErrInvalidLocality(loc domain.Locality) *ErrInvalidLocality {
+	return &ErrInvalidLocality{loc}
+}
+
+func (e ErrInvalidLocality) Error() string {
+	return fmt.Sprintf("locality already exists: %s, %s, %s", e.Locality.Name, e.Locality.Province, e.Locality.Country)
+}
+
+func NewErrNotFound(id int) *ErrNotFound {
+	return &ErrNotFound{id}
+}
+
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("locality with ID %d not found", e.ID)
+}

--- a/internal/localities/repository.go
+++ b/internal/localities/repository.go
@@ -32,9 +32,10 @@ func NewRepository(db *sql.DB) Repository {
 
 func (r *repository) Save(ctx context.Context, loc domain.Locality) (int, error) {
 	// This query inserts the domain's locality across 3 tables.
-	// It tries to inser the province and country names if they
+	// It tries to insert the province and country names if they
 	// don't exist, ignoring possible unique-constraint violations.
-	// The last INSERT should not be ignored, since it's
+	// The last INSERT should not be ignored, since its failure means
+	// that the whole locality already exists.
 	countryQuery := `INSERT IGNORE INTO countries (country_name) VALUES (?);`
 	provinceQuery := `
 		INSERT IGNORE INTO provinces (province_name, country_id)

--- a/internal/localities/repository.go
+++ b/internal/localities/repository.go
@@ -1,0 +1,134 @@
+package localities
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"strings"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+)
+
+type SellerCount struct {
+	LocalityID  int
+	SellerCount int
+}
+
+type Repository interface {
+	Create(c context.Context, loc domain.Locality) (int, error)
+	GetAll(c context.Context) ([]domain.Locality, error)
+	CountSellersByLocalities(c context.Context, ids []int) ([]SellerCount, error)
+}
+
+type repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) Repository {
+	return &repository{
+		db: db,
+	}
+}
+
+func (r *repository) Create(ctx context.Context, loc domain.Locality) (int, error) {
+	// This query inserts the domain's locality across 3 tables.
+	// It tries to inser the province and country names if they
+	// don't exist, ignoring possible unique-constraint violations.
+	// The last INSERT should not be ignored, since it's
+	countryQuery := `INSERT IGNORE INTO countries (country_name) VALUES (?);`
+	provinceQuery := `
+		INSERT IGNORE INTO provinces (province_name, country_id)
+			SELECT ?, c.id FROM countries c
+		WHERE c.country_name = ?;`
+	localityQuery := `
+		INSERT INTO localities (locality_name, province_id)
+			SELECT ?, p.id FROM provinces p
+		WHERE p.province_name = ?;`
+
+	r.db.Exec(countryQuery, loc.Country)
+	r.db.Exec(provinceQuery, loc.Province, loc.Country)
+	result, err := r.db.Exec(localityQuery, loc.Name, loc.Province)
+
+	if err != nil {
+		if isDuplicateError(err) {
+			return 0, NewErrInvalidLocality(loc)
+		}
+		return 0, err
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	return int(id), nil
+}
+
+func (r *repository) GetAll(c context.Context) ([]domain.Locality, error) {
+	query := `SELECT l.id, l.locality_name, p.province_name, c.country_name
+		FROM countries c JOIN provinces p ON c.id = p.country_id
+		JOIN localities l ON p.id = l.province_id;`
+
+	rows, err := r.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+
+	locs := make([]domain.Locality, 0)
+	for rows.Next() {
+		var loc domain.Locality
+		err := rows.Scan(&loc.ID, &loc.Name, &loc.Province, &loc.Country)
+		if err != nil {
+			log.Println(err.Error())
+			return nil, err
+		}
+		locs = append(locs, loc)
+	}
+
+	return locs, nil
+}
+
+func (r *repository) CountSellersByLocalities(c context.Context, ids []int) ([]SellerCount, error) {
+	if len(ids) == 0 {
+		return make([]SellerCount, 0), nil
+	}
+
+	query := `SELECT l.id, COUNT(s.id)
+		FROM localities l
+		LEFT JOIN sellers s ON s.locality_id = l.id
+		WHERE l.id IN (?` + strings.Repeat(",?", len(ids)-1) + `)
+		GROUP BY l.id, l.locality_name;`
+
+	queryArgs := convertToAny(ids)
+	rows, err := r.db.Query(query, queryArgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make([]SellerCount, 0)
+	for rows.Next() {
+		var count SellerCount
+		err := rows.Scan(&count.LocalityID, &count.SellerCount)
+		if err != nil {
+			log.Println(err.Error())
+			return nil, err
+		}
+		counts = append(counts, count)
+	}
+
+	return counts, nil
+}
+
+func isDuplicateError(err error) bool {
+	return strings.HasPrefix(err.Error(), "Error 1062")
+}
+
+func convertToAny[T any](x []T) []any {
+	ret := make([]any, len(x))
+
+	for i, xi := range x {
+		ret[i] = xi
+	}
+
+	return ret
+}

--- a/internal/localities/repository.go
+++ b/internal/localities/repository.go
@@ -15,7 +15,7 @@ type SellerCount struct {
 }
 
 type Repository interface {
-	Create(c context.Context, loc domain.Locality) (int, error)
+	Save(c context.Context, loc domain.Locality) (int, error)
 	GetAll(c context.Context) ([]domain.Locality, error)
 	CountSellersByLocalities(c context.Context, ids []int) ([]SellerCount, error)
 }
@@ -30,7 +30,7 @@ func NewRepository(db *sql.DB) Repository {
 	}
 }
 
-func (r *repository) Create(ctx context.Context, loc domain.Locality) (int, error) {
+func (r *repository) Save(ctx context.Context, loc domain.Locality) (int, error) {
 	// This query inserts the domain's locality across 3 tables.
 	// It tries to inser the province and country names if they
 	// don't exist, ignoring possible unique-constraint violations.

--- a/internal/localities/service.go
+++ b/internal/localities/service.go
@@ -1,0 +1,116 @@
+package localities
+
+import (
+	"context"
+	"errors"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/optional"
+)
+
+type CreateDTO struct {
+	Name     string
+	Province string
+	Country  string
+}
+
+type SellersByLocality struct {
+	Name  string
+	Count int
+}
+
+type Service interface {
+	Create(c context.Context, loc CreateDTO) (domain.Locality, error)
+	// godoc CountSellers
+	//  Returns slice of Seller count by Locality. If id is specified,
+	//  the slice will only contain the count for that locality; otherwise,
+	//  the slice will contain all localities.
+	CountSellers(c context.Context, id optional.Opt[int]) ([]SellersByLocality, error)
+}
+
+type service struct {
+	repo Repository
+}
+
+func NewService(repo Repository) Service {
+	return &service{repo}
+}
+
+func (svc *service) Create(c context.Context, loc CreateDTO) (domain.Locality, error) {
+	locDomain := MapCreateToDomain(loc)
+
+	id, err := svc.repo.Create(c, locDomain)
+	if err != nil {
+		var errInvalidLoc *ErrInvalidLocality
+		if errors.As(err, &errInvalidLoc) {
+			return domain.Locality{}, err
+		} else {
+			return domain.Locality{}, NewErrGeneric("error saving locality")
+		}
+	}
+	locDomain.ID = id
+
+	return locDomain, nil
+}
+
+func (svc *service) CountSellers(c context.Context, id optional.Opt[int]) ([]SellersByLocality, error) {
+	locs, err := svc.repo.GetAll(c)
+	if err != nil {
+		return nil, NewErrGeneric("error fetching localities")
+	}
+
+	index := getLocalityIndex(locs)
+	ids := getReportIDs(id, index)
+
+	stats, err := svc.repo.CountSellersByLocalities(c, ids)
+	if err != nil {
+		return nil, NewErrGeneric("error counting sellers")
+	}
+	if id.HasVal && len(stats) == 0 {
+		return nil, NewErrNotFound(id.Val)
+	}
+
+	report := make([]SellersByLocality, 0)
+	for _, stat := range stats {
+		loc := index[stat.LocalityID]
+		locCount := newSellersByLocality(loc, stat.SellerCount)
+		report = append(report, locCount)
+	}
+
+	return report, nil
+}
+
+func newSellersByLocality(loc domain.Locality, count int) SellersByLocality {
+	return SellersByLocality{
+		Name:  loc.Name,
+		Count: count,
+	}
+}
+
+func getReportIDs(id optional.Opt[int], idx map[int]domain.Locality) []int {
+	if ID, hasVal := id.Value(); hasVal {
+		return []int{ID}
+	}
+
+	ids := make([]int, 0)
+	for _, loc := range idx {
+		ids = append(ids, loc.ID)
+	}
+	return ids
+}
+
+func getLocalityIndex(locs []domain.Locality) map[int]domain.Locality {
+	index := make(map[int]domain.Locality)
+	for _, loc := range locs {
+		index[loc.ID] = loc
+	}
+	return index
+}
+
+func MapCreateToDomain(dto CreateDTO) domain.Locality {
+	return domain.Locality{
+		Name:     dto.Name,
+		Province: dto.Province,
+		Country:  dto.Country,
+	}
+}

--- a/internal/localities/service.go
+++ b/internal/localities/service.go
@@ -15,6 +15,7 @@ type CreateDTO struct {
 }
 
 type SellersByLocality struct {
+	ID    int
 	Name  string
 	Count int
 }
@@ -39,7 +40,7 @@ func NewService(repo Repository) Service {
 func (svc *service) Create(c context.Context, loc CreateDTO) (domain.Locality, error) {
 	locDomain := MapCreateToDomain(loc)
 
-	id, err := svc.repo.Create(c, locDomain)
+	id, err := svc.repo.Save(c, locDomain)
 	if err != nil {
 		var errInvalidLoc *ErrInvalidLocality
 		if errors.As(err, &errInvalidLoc) {
@@ -82,6 +83,7 @@ func (svc *service) CountSellers(c context.Context, id optional.Opt[int]) ([]Sel
 
 func newSellersByLocality(loc domain.Locality, count int) SellersByLocality {
 	return SellersByLocality{
+		ID:    loc.ID,
 		Name:  loc.Name,
 		Count: count,
 	}

--- a/internal/localities/service_test.go
+++ b/internal/localities/service_test.go
@@ -6,30 +6,189 @@ import (
 
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/localities"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/optional"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestCreate(t *testing.T) {
 	t.Run("Creates valid locality", func(t *testing.T) {
-		t.Skip()
+		repo := RepositoryMock{}
+		svc := localities.NewService(&repo)
+
+		dto := localities.CreateDTO{
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "Brasil",
+		}
+		expected := domain.Locality{
+			ID:       1,
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "Brasil",
+		}
+		repo.On("Save", mock.Anything, mock.Anything).Return(1, nil)
+
+		received, err := svc.Create(context.TODO(), dto)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, received)
 	})
 	t.Run("Doesn't create duplicate locality", func(t *testing.T) {
-		t.Skip()
+		repo := RepositoryMock{}
+		svc := localities.NewService(&repo)
+
+		dto := localities.CreateDTO{
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "Brasil",
+		}
+		loc := domain.Locality{
+			Name:     "Melicidade",
+			Province: "SP",
+			Country:  "Brasil",
+		}
+		var expectedErr *localities.ErrInvalidLocality
+		repo.On("Save", mock.Anything, mock.Anything).Return(0, localities.NewErrInvalidLocality(loc))
+
+		_, err := svc.Create(context.TODO(), dto)
+
+		assert.ErrorAs(t, err, &expectedErr)
 	})
 }
 
 func TestReport(t *testing.T) {
 	t.Run("Returns all localities when id is omitted", func(t *testing.T) {
-		t.Skip()
+		repo := RepositoryMock{}
+		svc := localities.NewService(&repo)
+
+		noID := optional.Opt[int]{}
+
+		expected := []localities.SellersByLocality{
+			{
+				ID:    1,
+				Name:  "Melicidade",
+				Count: 2,
+			},
+			{
+				ID:    2,
+				Name:  "Tesla",
+				Count: 1,
+			},
+		}
+		counts := []localities.SellerCount{
+			{
+				LocalityID:  1,
+				SellerCount: 2,
+			},
+			{
+				LocalityID:  2,
+				SellerCount: 1,
+			},
+		}
+		locs := getLocalities()
+
+		repo.On("GetAll", mock.Anything).Return(locs, nil)
+		repo.On("CountSellersByLocalities", mock.Anything, mock.Anything).Return(counts, nil)
+
+		received, err := svc.CountSellers(context.TODO(), noID)
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, expected, received)
 	})
 	t.Run("Returns specific locality if id is provided", func(t *testing.T) {
-		t.Skip()
+		repo := RepositoryMock{}
+		svc := localities.NewService(&repo)
+
+		id := *optional.FromVal(2)
+
+		expected := []localities.SellersByLocality{
+			{
+				ID:    2,
+				Name:  "Tesla",
+				Count: 1,
+			},
+		}
+		counts := []localities.SellerCount{
+			{
+				LocalityID:  2,
+				SellerCount: 1,
+			},
+		}
+		locs := getLocalities()
+
+		repo.On("GetAll", mock.Anything).Return(locs, nil)
+		repo.On("CountSellersByLocalities", mock.Anything, []int{id.Val}).Return(counts, nil)
+
+		received, err := svc.CountSellers(context.TODO(), id)
+
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, expected, received)
 	})
 	t.Run("Returns NotFound if id doesn't exist", func(t *testing.T) {
-		t.Skip()
+		repo := RepositoryMock{}
+		svc := localities.NewService(&repo)
+
+		id := *optional.FromVal(7)
+
+		counts := []localities.SellerCount{}
+		locs := getLocalities()
+		var expectedErr *localities.ErrNotFound
+
+		repo.On("GetAll", mock.Anything).Return(locs, nil)
+		repo.On("CountSellersByLocalities", mock.Anything, []int{id.Val}).Return(counts, nil)
+
+		_, err := svc.CountSellers(context.TODO(), id)
+
+		assert.ErrorAs(t, err, &expectedErr)
 	})
 	t.Run("Doesn't return NotFound if id is omitted but no data exists", func(t *testing.T) {
-		t.Skip()
+		repo := RepositoryMock{}
+		svc := localities.NewService(&repo)
+
+		noID := optional.Opt[int]{}
+
+		counts := []localities.SellerCount{}
+		locs := getLocalities()
+
+		repo.On("GetAll", mock.Anything).Return(locs, nil)
+		repo.On("CountSellersByLocalities", mock.Anything, mock.Anything).Return(counts, nil)
+
+		received, err := svc.CountSellers(context.TODO(), noID)
+
+		assert.NoError(t, err)
+		assert.Len(t, received, 0)
 	})
 }
 
+func getLocalities() []domain.Locality {
+	return []domain.Locality{
+		{
+			ID:   1,
+			Name: "Melicidade",
+		},
+		{
+			ID:   2,
+			Name: "Tesla",
+		},
+	}
+}
+
+type RepositoryMock struct {
+	mock.Mock
+}
+
+func (r *RepositoryMock) Save(c context.Context, loc domain.Locality) (int, error) {
+	args := r.Called(c, loc)
+	return args.Get(0).(int), args.Error(1)
+}
+
+func (r *RepositoryMock) GetAll(c context.Context) ([]domain.Locality, error) {
+	args := r.Called(c)
+	return args.Get(0).([]domain.Locality), args.Error(1)
+}
+
+func (r *RepositoryMock) CountSellersByLocalities(c context.Context, ids []int) ([]localities.SellerCount, error) {
+	args := r.Called(c, ids)
+	return args.Get(0).([]localities.SellerCount), args.Error(1)
+}

--- a/internal/localities/service_test.go
+++ b/internal/localities/service_test.go
@@ -1,0 +1,35 @@
+package localities_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/localities"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCreate(t *testing.T) {
+	t.Run("Creates valid locality", func(t *testing.T) {
+		t.Skip()
+	})
+	t.Run("Doesn't create duplicate locality", func(t *testing.T) {
+		t.Skip()
+	})
+}
+
+func TestReport(t *testing.T) {
+	t.Run("Returns all localities when id is omitted", func(t *testing.T) {
+		t.Skip()
+	})
+	t.Run("Returns specific locality if id is provided", func(t *testing.T) {
+		t.Skip()
+	})
+	t.Run("Returns NotFound if id doesn't exist", func(t *testing.T) {
+		t.Skip()
+	})
+	t.Run("Doesn't return NotFound if id is omitted but no data exists", func(t *testing.T) {
+		t.Skip()
+	})
+}
+


### PR DESCRIPTION
This PR adds support for Locality creation, as well as for generating a report for how many sellers there are in each locality.
It includes 100% coverage tests in the Service and Controller layers, still missing the required Repository tests.