### PR TITLE
Add initial entities' repository tests

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -199,6 +199,7 @@ CREATE TABLE IF NOT EXISTS `melisprint`.`product_batches` (
   PRIMARY KEY (`id`),
   INDEX `product_id_idx` (`product_id` ASC) VISIBLE,
   INDEX `section_id_idx` (`section_id` ASC) VISIBLE,
+  CONSTRAINT `batch_number` UNIQUE (`batch_number`),
   CONSTRAINT `fk_product_product_batches`
     FOREIGN KEY (`product_id`)
     REFERENCES `melisprint`.`products` (`id`)

--- a/db.sql
+++ b/db.sql
@@ -255,6 +255,7 @@ CREATE TABLE IF NOT EXISTS `melisprint`.`carriers` (
   `telephone` VARCHAR(255) NOT NULL,
   `locality_id` INT NOT NULL,
   PRIMARY KEY (`id`),
+  CONSTRAINT `cid` UNIQUE (`cid`),
   INDEX `locality_id_idx` (`locality_id` ASC) VISIBLE,
   CONSTRAINT `fk_locality_carrier`
     FOREIGN KEY (`locality_id`)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/extmatperez/meli_bootcamp_go_w2-4
 go 1.20
 
 require (
+	github.com/DATA-DOG/go-txdb v0.1.6
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
@@ -31,6 +33,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-txdb v0.1.6 h1:D1Ob/L79mCW6UCFL6vwM/9TWs/rshZujxTsvy7+gicw=
+github.com/DATA-DOG/go-txdb v0.1.6/go.mod h1:DhAhxMXZpUJVGnT+p9IbzJoRKvlArO2pkHjnGX7o0n0=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
@@ -44,6 +46,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -58,6 +62,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=

--- a/internal/batches/repository_test.go
+++ b/internal/batches/repository_test.go
@@ -1,0 +1,69 @@
+package batches_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/batches"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/testutil"
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepositoryCreate(t *testing.T) {
+	t.Run("Creates valid batch", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := batches.NewRepository(db)
+
+		batch := domain.Batches{
+			BatchNumber:        321874,
+			CurrentQuantity:    1,
+			CurrentTemperature: 2,
+			DueDate:            time.Unix(100000, 1000),
+			InitialQuantity:    10,
+			ManufacturingDate:  time.Unix(100000, 1000),
+			ManufacturingHour:  12,
+			MinimumTemperature: 0,
+			ProductID:          1,
+			SectionID:          1,
+		}
+
+		id, _ := repo.Save(context.TODO(), batch)
+
+		var receivedNumber int
+		row := db.QueryRow(`SELECT batch_number FROM product_batches WHERE id = ?;`, id)
+		row.Scan(&receivedNumber)
+
+		assert.Equal(t, batch.BatchNumber, receivedNumber)
+	})
+	t.Run("Does not create invalid batch", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := batches.NewRepository(db)
+
+		batch := domain.Batches{
+			BatchNumber:        321874,
+			CurrentQuantity:    1,
+			CurrentTemperature: 2,
+			DueDate:            time.Unix(100000, 1000),
+			InitialQuantity:    10,
+			ManufacturingDate:  time.Unix(100000, 1000),
+			ManufacturingHour:  12,
+			MinimumTemperature: 0,
+			ProductID:          1,
+			SectionID:          1,
+		}
+
+		_, err := repo.Save(context.TODO(), batch)
+		assert.NoError(t, err)
+
+		_, err = repo.Save(context.TODO(), batch)
+		assert.Error(t, err)
+	})
+}

--- a/internal/carrier/repository_test.go
+++ b/internal/carrier/repository_test.go
@@ -1,0 +1,58 @@
+package carrier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/carrier"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/testutil"
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepositoryCreate(t *testing.T) {
+	t.Run("Creates valid carrier", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := carrier.NewRepository(db)
+
+		c := domain.Carrier{
+			CID:         873456,
+			CompanyName: "meli",
+			Address:     "osasco",
+			Telephone:   "99999",
+			LocalityID:  1,
+		}
+
+		id, _ := repo.Create(context.TODO(), c)
+		var receivedCid int
+
+		row := db.QueryRow(`SELECT cid FROM carriers WHERE id = ?;`, id)
+		row.Scan(&receivedCid)
+
+		assert.Equal(t, c.CID, receivedCid)
+	})
+	t.Run("Does not create invalid carrier", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := carrier.NewRepository(db)
+
+		c := domain.Carrier{
+			CID:         873456,
+			CompanyName: "meli",
+			Address:     "osasco",
+			Telephone:   "99999",
+			LocalityID:  1,
+		}
+
+		_, err := repo.Create(context.TODO(), c)
+		assert.NoError(t, err)
+
+		_, err = repo.Create(context.TODO(), c)
+		assert.Error(t, err)
+	})
+}

--- a/internal/carrier/service_test.go
+++ b/internal/carrier/service_test.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/extmatperez/meli_bootcamp_go_w2-4/cmd/server/handler"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/carrier"
 	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
-	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -72,16 +70,6 @@ func TestCreate(t *testing.T) {
 
 		assert.ErrorIs(t, err, carrier.ErrInternalServerError)
 	})
-}
-
-func getTestCarrierRequest() handler.CarrierRequest {
-	return handler.CarrierRequest{
-		CID:         testutil.ToPtr(10),
-		CompanyName: testutil.ToPtr("mercado livre"),
-		Address:     testutil.ToPtr("osasco"),
-		Telephone:   testutil.ToPtr("123456789"),
-		LocalityID:  testutil.ToPtr(5),
-	}
 }
 
 func getTestCarrierDTO() carrier.CarrierDTO {

--- a/internal/inbound_order/repository_test.go
+++ b/internal/inbound_order/repository_test.go
@@ -1,0 +1,59 @@
+package inboundorder_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	inboundorder "github.com/extmatperez/meli_bootcamp_go_w2-4/internal/inbound_order"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/testutil"
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreate(t *testing.T) {
+	t.Run("Creates valid inbound order", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := inboundorder.NewRepository(db)
+
+		order := domain.InboundOrder{
+			OrderDate:      time.Now().AddDate(0, 0, 1),
+			OrderNumber:    "123456",
+			EmployeeID:     1,
+			ProductBatchID: 2,
+			WarehouseID:    1,
+		}
+
+		id, _ := repo.Save(context.TODO(), order)
+		var receivedNumber string
+
+		row := db.QueryRow(`SELECT order_number FROM inbound_orders WHERE id = ?;`, id)
+		row.Scan(&receivedNumber)
+
+		assert.Equal(t, order.OrderNumber, receivedNumber)
+	})
+	t.Run("Does not create invalid inbound order", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := inboundorder.NewRepository(db)
+
+		order := domain.InboundOrder{
+			OrderDate:      time.Now().AddDate(0, 0, 1),
+			OrderNumber:    "123456",
+			EmployeeID:     1,
+			ProductBatchID: 2,
+			WarehouseID:    1,
+		}
+
+		_, err := repo.Save(context.TODO(), order)
+		assert.NoError(t, err)
+
+		_, err = repo.Save(context.TODO(), order)
+		assert.Error(t, err)
+	})
+}

--- a/internal/localities/repository_test.go
+++ b/internal/localities/repository_test.go
@@ -1,0 +1,54 @@
+package localities_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/domain"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/internal/localities"
+	"github.com/extmatperez/meli_bootcamp_go_w2-4/pkg/testutil"
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepositoryCreate(t *testing.T) {
+	t.Run("Creates valid locality", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := localities.NewRepository(db)
+
+		loc := domain.Locality{
+			Name:     "Melicidade-2",
+			Province: "SP",
+			Country:  "BR",
+		}
+
+		id, _ := repo.Save(context.TODO(), loc)
+		var receivedName string
+
+		row := db.QueryRow(`SELECT locality_name FROM localities WHERE id = ?;`, id)
+		row.Scan(&receivedName)
+
+		assert.Equal(t, loc.Name, receivedName)
+	})
+	t.Run("Does not create invalid locality", func(t *testing.T) {
+		db := testutil.InitDatabase(t)
+		defer db.Close()
+
+		repo := localities.NewRepository(db)
+
+		loc := domain.Locality{
+			Name:     "Melicidade-2",
+			Province: "SP",
+			Country:  "BR",
+		}
+
+		_, err := repo.Save(context.TODO(), loc)
+		assert.NoError(t, err)
+
+		_, err = repo.Save(context.TODO(), loc)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/testutil/db.go
+++ b/pkg/testutil/db.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-txdb"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	txdb.Register("txdb", "mysql", "meli_sprint_user:Meli_Sprint#123@/melisprint")
+}
+
+func InitDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("txdb", uuid.New().String())
+	assert.NoError(t, err)
+	return db
+}


### PR DESCRIPTION
This PR adds the required unit tests in the repository layer of the following entities:
* Product batches
* Localities
* inbound orders
* Carriers

The tests use TXDB.